### PR TITLE
Update read_file.c

### DIFF
--- a/read_file.c
+++ b/read_file.c
@@ -72,7 +72,7 @@ char *read_file(char *filename)
   char *string = malloc(sizeof(char) * (length+1));
   
   // c will store each char we read from the string
-  char c;
+  int c;
 
   // i will be an index into the char array string as we read each char
   int i = 0;


### PR DESCRIPTION
Variable c in read_file() must be defined as int since fgetc() returns the character read as an int. By defining c as a char, the while loop might break prematurely if the input file contains "&yuml;" somewhere since this character is sometimes encoded as hex FF, which is  -1 for a signed char.